### PR TITLE
Fix/notifications listdisplay permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ Get the app at https://tickybott.herokuapp.com/
 ## Usage
 - Use `/ticket help` to see usage instructions
 - Use `/ticket show` to see open and/or solved tickets
-#### Users
 - Use `/ticket [message]` or `/ticket open [message]` to open a new ticket
-- Use `/ticket unsolve #[ticket number]` to reopen a solved ticket if the issue hasn't been fixed
-- Use `/ticket close #[ticket number]` to close a solved ticket
-
 #### Team owners and admins:
 - Use `/ticket solve #[ticket number]` to mark tickets as solved and notify their authors
+#### Team members
+- Use `/ticket unsolve #[ticket number]` to reopen a solved ticket if the issue hasn't been fixed
+- Use `/ticket close #[ticket number]` to close a solved ticket
 
 ## Authors
 * [osycon](https://github.com/osycon) (Team Leader)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1935,11 +1935,6 @@
         "delayed-stream": "1.0.0"
       }
     },
-    "commander": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz",
-      "integrity": "sha1-nfflL7Kgyw+4kFjugMMQQiXzfh0="
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1985,81 +1980,6 @@
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
         "typedarray": "0.0.6"
-      }
-    },
-    "concurrently": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz",
-      "integrity": "sha1-jPG3cHppFqeKT/W3e7BN7FSzebI=",
-      "requires": {
-        "chalk": "0.5.1",
-        "commander": "2.6.0",
-        "date-fns": "1.28.5",
-        "lodash": "4.17.4",
-        "rx": "2.3.24",
-        "spawn-command": "0.0.2-1",
-        "supports-color": "3.2.3",
-        "tree-kill": "1.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
-          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
-        },
-        "ansi-styles": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
-          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
-        },
-        "chalk": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
-          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
-          "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
-              "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
-          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
-        },
-        "strip-ansi": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
-          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
-          "requires": {
-            "ansi-regex": "0.2.1"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "1.0.0"
-          }
-        }
       }
     },
     "configstore": {
@@ -2520,11 +2440,6 @@
       "requires": {
         "assert-plus": "1.0.0"
       }
-    },
-    "date-fns": {
-      "version": "1.28.5",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz",
-      "integrity": "sha1-JXz8RdMi30XvVlhmWWfuhBzXP68="
     },
     "date-now": {
       "version": "0.1.4",
@@ -3088,7 +3003,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.9.0",
@@ -9289,11 +9205,6 @@
         "is-promise": "2.1.0"
       }
     },
-    "rx": {
-      "version": "2.3.24",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.24.tgz",
-      "integrity": "sha1-FPlQpCF9fjXapxu8vljv9o6ksrc="
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -9858,11 +9769,6 @@
         }
       }
     },
-    "spawn-command": {
-      "version": "0.0.2-1",
-      "resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2-1.tgz",
-      "integrity": "sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A="
-    },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
@@ -10367,11 +10273,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
       "dev": true
-    },
-    "tree-kill": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
-      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg=="
     },
     "trim-newlines": {
       "version": "1.0.0",

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -17,7 +17,7 @@ module.exports = (app) => {
       },
     };
     // Exchnge temporary code fro access tokens
-    request.post('https://slack.com/api/oauth.access', data, async (error, response, body) => {
+    request.post('https://slack.com/api/oauth.access', data, (error, response, body) => {
       if (!error && response.statusCode === 200) {
         const { team_id, access_token, bot: { bot_access_token } } = JSON.parse(body);
         // Save user's access tokens to database

--- a/server/controllers/handleInteractiveMsg.js
+++ b/server/controllers/handleInteractiveMsg.js
@@ -14,7 +14,7 @@ module.exports = async (req, res) => {
     user: { id: userId, name: username },
     team: { id: teamId },
     response_url: responseURL,
-    actions: [{ name: command, value: data }],
+    actions: [{ name: command, value: ticket }],
   } = res.locals.payload;
 
   const isAdmin = (await getUserInfo(userId, teamId)).is_admin;
@@ -26,7 +26,7 @@ module.exports = async (req, res) => {
     username,
     teamId,
     command,
-    data, // contains existing ticket id OR new ticket text
+    ticket: ticket && JSON.parse(ticket),
   };
 
   // Determine and call an appropriate response

--- a/server/handlers/slackApiHandlers.js
+++ b/server/handlers/slackApiHandlers.js
@@ -25,25 +25,23 @@ exports.getUserInfo = async (userId, teamId) => {
 /**
  * Notofies user when their ticket is solved
  * REQUIRES chat:write, im:read, post, read scopes at
- * @param {string} userId
+ * @param {string} authorId
  * @param {string} message - Message text to send to the user
  */
-exports.sendDM = async (userId, teamId, ticketNumber) => {
+exports.sendDM = async (authorId, userId, teamId, ticketNumber, text) => {
   const token = (await getTokensByTeam(teamId)).botToken;
-
   // Get ticket owner's direct message channel id
   const imList = await request.post('https://slack.com/api/im.list', {
     form: { token },
   });
-  const userChannelId = JSON.parse(imList).ims.find(channel => channel.user === userId).id;
 
   request.post('https://slack.com/api/chat.postMessage', {
     form: {
       token,
-      id: 'ticket-solved',
       as_user: false,
-      text: msg.notify(ticketNumber),
-      channel: userChannelId,
+      id: 'ticket-solved',
+      text: msg.notify(ticketNumber, userId, text),
+      channel: JSON.parse(imList).ims.find(ch => ch.user === authorId).id,
     },
   });
 };

--- a/server/utils/attachments.js
+++ b/server/utils/attachments.js
@@ -29,29 +29,25 @@ exports.show = ({ isAdmin, userId, teamId }) => {
     mrkdwn_in: ['pretext', 'text', 'fields'],
     color: '#36a64f',
   };
+
   return Promise.all(promises)
     .then((tickets) => {
-      const ticketsOpen = tickets[0] && Object.values(tickets[0]);
-      const ticketsSolved = tickets[1] && Object.values(tickets[1]);
+      const ticketsOpen =
+        tickets[0] && Object.values(tickets[0]).filter(ticket => ticket.team === teamId);
+      const ticketsSolved =
+        tickets[1] && Object.values(tickets[1]).filter(ticket => ticket.team === teamId);
 
       // If no tickets in database
       if (!ticketsOpen && !ticketsSolved) {
         return { ...base, text: msg.show.list.empty };
       }
 
-      // FIXME format visible ticket
-      const format = arr =>
-        arr
-          .map(ticket =>
-            `*#${ticket.number}* ${ticket.text}${isAdmin ? ` from <@${ticket.author}>` : ''}`)
-          .join('\n');
-
       if (isAdmin) {
         return {
           ...base,
           pretext: examples.short.admin,
           title: msg.show.title.adminTitle,
-          text: ticketsOpen ? format(ticketsOpen) : msg.show.list.noOpen,
+          text: ticketsOpen ? msg.show.list.format(ticketsOpen, isAdmin) : msg.show.list.noOpen,
         };
       }
       return {
@@ -61,11 +57,11 @@ exports.show = ({ isAdmin, userId, teamId }) => {
         fields: [
           {
             title: msg.show.title.userSolved,
-            value: ticketsSolved ? format(ticketsSolved) : msg.show.list.noSolved,
+            value: ticketsSolved ? msg.show.list.format(ticketsSolved) : msg.show.list.noSolved,
           },
           {
             title: msg.show.title.userOpen,
-            value: ticketsOpen ? format(ticketsOpen) : msg.show.list.noOpen,
+            value: ticketsOpen ? msg.show.list.format(ticketsOpen) : msg.show.list.noOpen,
           },
         ],
       };
@@ -106,24 +102,24 @@ exports.helpOrShowInteractive = (isAdmin, message) => ({
  * @returns {object} Constructed attachment to send with a response message
  */
 exports.confirm = (command, ticket) => ({
-    color: '#ffd740',
-    text: msg.confirm.text(command, ticket),
-    mrkdwn_in: ['text', 'actions'],
-    callback_id: `CONFIRM_${command}`,
-    attachment_type: 'default',
-    actions: [
-      {
-        name: 'CANCEL',
-        text: msg.btn.no,
-        style: 'danger',
-        type: 'button',
+  color: '#ffd740',
+  text: msg.confirm.text(command, ticket),
+  mrkdwn_in: ['text', 'actions'],
+  callback_id: `CONFIRM_${command}`,
+  attachment_type: 'default',
+  actions: [
+    {
+      name: 'CANCEL',
+      text: msg.btn.no,
+      style: 'danger',
+      type: 'button',
       value: '',
-      },
-      {
-        name: command,
-        text: msg.btn.yes(command),
-        type: 'button',
+    },
+    {
+      name: command,
+      text: msg.btn.yes(command),
+      type: 'button',
       value: JSON.stringify(ticket),
-      },
-    ],
+    },
+  ],
 });

--- a/server/utils/attachments.js
+++ b/server/utils/attachments.js
@@ -89,13 +89,13 @@ exports.helpOrShowInteractive = (isAdmin, message) => ({
       name: 'HELP',
       text: 'Help',
       type: 'button',
-      value: 'help',
+      value: '',
     },
     {
       name: 'SHOW',
       text: msg.btn.view,
       type: 'button',
-      value: 'show',
+      value: '',
     },
   ],
 });
@@ -105,9 +105,7 @@ exports.helpOrShowInteractive = (isAdmin, message) => ({
  * @param {object} ticket: {id, text, number} - Ticket referenced in a slash command
  * @returns {object} Constructed attachment to send with a response message
  */
-exports.confirm = (command, ticket) => {
-  const { id, text } = ticket;
-  return {
+exports.confirm = (command, ticket) => ({
     color: '#ffd740',
     text: msg.confirm.text(command, ticket),
     mrkdwn_in: ['text', 'actions'],
@@ -119,14 +117,13 @@ exports.confirm = (command, ticket) => {
         text: msg.btn.no,
         style: 'danger',
         type: 'button',
-        value: 'cancel',
+      value: '',
       },
       {
         name: command,
         text: msg.btn.yes(command),
         type: 'button',
-        value: id || text, // id is only undefined when OPENing a new ticket
+      value: JSON.stringify(ticket),
       },
     ],
-  };
-};
+});

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -3,7 +3,7 @@ exports.commands = ['HELP', 'SHOW', 'OPEN', 'CLOSE', 'UNSOLVE', 'SOLVE'];
 exports.examples = {
   full: {
     user: [
-      'Use `/ticket` to report issues and problems to team admins. You will be notified when your issue has been fixed.',
+      'Use `/ticket` to report issues and problems to team admins.',
       '`/ticket help` to show usage instructions.',
       '`/ticket show` to show a list of your solved and open tickets.',
       '`/ticket [message]` or `/ticket open [message]` to open a new ticket.',
@@ -13,6 +13,7 @@ exports.examples = {
     admin: [
       '`/ticket help` to show usage instructions.',
       '`/ticket show` to show a list of open tickets.',
+      '`/ticket [message]` or `/ticket open [message]` to open a new ticket.',
       '`/ticket solve #[ticket number]` to solve a ticket and notifiy the author.',
     ],
   },

--- a/server/utils/helpers.js
+++ b/server/utils/helpers.js
@@ -11,12 +11,9 @@ const upperCaseFirst = str => str.charAt(0).toUpperCase() + str.slice(1).toLower
  * @param {string} inputText
  */
 exports.parseInputText = (inputText) => {
-  if (!inputText) {
-    return { command: 'HELLO' };
-  }
+  if (!inputText) return { command: 'HELLO' };
 
   let command;
-  let message;
   let number;
 
   // Tokenize input and uppercase first word
@@ -30,27 +27,26 @@ exports.parseInputText = (inputText) => {
     tokenized = tokenized.filter(token => token !== ticketReference[0]);
   }
 
-  // Join message and set no-command to OPEN command
-  if (commands.includes(command)) {
-    message = tokenized.splice(1).join(' ');
-  } else {
-    message = tokenized.join(' ');
+  if (!commands.includes(command)) {
     command = 'OPEN';
+    tokenized.unshift(command);
   }
 
-  // If required number or message missing, return ERROR command
-  if (
-    (!message && command === 'OPEN') ||
-    (!number && (command === 'SOLVE' || command === 'UNSOLVE' || command === 'CLOSE'))
-  ) {
-    command = 'ERROR';
-  }
+  const message = tokenized.splice(1).join(' ');
 
-  return {
-    command,
-    message,
-    number,
-  };
+  switch (command) {
+    case 'OPEN':
+      return message ? { command, message } : { command: 'ERROR' };
+    case 'CLOSE':
+    case 'SOLVE':
+    case 'UNSOLVE':
+      return number ? { command, number } : { command: 'ERROR' };
+    case 'HELP':
+    case 'SHOW':
+      return { command };
+    default:
+      return { command: 'ERROR' };
+  }
 };
 
 exports.msg = {

--- a/server/utils/helpers.js
+++ b/server/utils/helpers.js
@@ -76,6 +76,7 @@ exports.msg = {
   },
   error: {
     text: ":thinking_face: I'm sorry, I don't understand. Check usage instructions below:",
+    notAuthor: number => `:no_entry_sign: Ticket *#${number}* is not yours.`,
     badTeam: number => `:no_entry_sign: Ticket *#${number}* doesn't exist in this team.`,
     notAllowedStatus: ({ number, author, status }) =>
       `:no_entry_sign: Not allowed. Ticket *#${number}* from <@${author}> is *${status}*.`,

--- a/server/utils/helpers.js
+++ b/server/utils/helpers.js
@@ -67,6 +67,11 @@ exports.msg = {
       empty: 'No tickets to show :success-bunny:',
       noOpen: 'No open tickets to show :success-bunny:',
       noSolved: 'No solved tickets to show.',
+      format: (list, isAdmin = false) =>
+        list
+          .map(ticket =>
+            `*#${ticket.number}* ${ticket.text}${isAdmin ? ` from <@${ticket.author}>` : ''}`)
+          .join('\n'),
     },
   },
   error: {
@@ -100,5 +105,6 @@ exports.msg = {
     confirm: command => upperCaseFirst(command),
     view: 'View all',
   },
-  notify: number => `Your ticket *#${number}* has been solved :success-bunny:`,
+  notify: (number, userId, text) =>
+    `Your ticket has been solved by <@${userId}>: *#${number}* ${text}`,
 };

--- a/server/utils/responses.js
+++ b/server/utils/responses.js
@@ -43,16 +43,9 @@ exports.ERROR = ({ isAdmin }) => ({
 
 // INITIAL SLASH COMMAND RESPONSES
 
-exports.OPEN = async ({ isAdmin, command, ticket }) => {
-  if (isAdmin) {
-    return {
-      mrkdwn_in: ['text', 'attachments'],
-      text: msg.help.text,
-      attachments: [attach.usage(isAdmin)],
-    };
-  }
-  return ticket.text && { attachments: [attach.confirm(command, ticket)] };
-};
+exports.OPEN = async ({ command, ticket }) => ({
+  attachments: [attach.confirm(command, ticket)],
+});
 
 exports.CLOSE = async ({
   isAdmin, command, userId, ticket,

--- a/server/utils/responses.js
+++ b/server/utils/responses.js
@@ -68,6 +68,7 @@ exports.SOLVE = async ({
   } else if (isAdmin) {
     return { attachments: [attach.confirm(command, ticket)] };
   }
+  return { text: msg.error.notAllowed, attachments: [attach.usage(isAdmin)] };
 };
 
 exports.UNSOLVE = async ({


### PR DESCRIPTION
### Summary
- Fix solved tickets list display
- Fix solved tickets notifications
- Prevent notifications for admins solving their own tickets
- Rewrite initial slash input parser to use `switch` statements for readability
- Allow admins to open tickets
- Limit displayed tickets to within the team
- Minor fixes and formatting

Closes #49 
Closes #48 