### PR TITLE
Tests and firebase handlers updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.env.test
 
 
 ### VisualStudioCode ###

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "homepage": "https://tickybott.herokuapp.com/",
   "scripts": {
-    "test": "jest --watchAll --coverage",
+    "test": "jest -i --watchAll --coverage",
     "dev:client": "NODE_ENV=development webpack-dev-server",
     "dev:server": "nodemon -r dotenv/config ./server/server.js",
     "dev": "npm-run-all -pnr test dev:*",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "author": "Osycon, thinktwice13, miljan-fsd, Zsolti",
   "license": "MIT",
   "eslintConfig": {
-    "extends": "airbnb-base"
+    "extends": "airbnb-base",
+    "env": { "jest": true }
   },
   "dependencies": {
     "body-parser": "^1.18.2",

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -1,6 +1,7 @@
 const request = require('request');
 const path = require('path');
 const { setTokens } = require('../handlers/firebaseHandlers');
+const { getTeamInfo } = require('../handlers/slackApiHandlers');
 
 module.exports = (app) => {
   app.get('/slack', (req, res) => {
@@ -17,11 +18,12 @@ module.exports = (app) => {
       },
     };
     // Exchnge temporary code fro access tokens
-    request.post('https://slack.com/api/oauth.access', data, (error, response, body) => {
+    request.post('https://slack.com/api/oauth.access', data, async (error, response, body) => {
       if (!error && response.statusCode === 200) {
         const { team_id, access_token, bot: { bot_access_token } } = JSON.parse(body);
         // Save user's access tokens to database
         setTokens(team_id, access_token, bot_access_token);
+        // const teamDomain = (await getTeamInfo(access_token)).domain; // Get team domain name
         res.redirect('/success.html');
       }
     });

--- a/server/controllers/handleInteractiveMsg.js
+++ b/server/controllers/handleInteractiveMsg.js
@@ -11,7 +11,7 @@ module.exports = async (req, res) => {
    */
   const {
     callback_id: callbackId,
-    user: { id: userId, name: username },
+    user: { id: userId },
     team: { id: teamId },
     response_url: responseURL,
     actions: [{ name: command, value: ticket }],
@@ -23,7 +23,6 @@ module.exports = async (req, res) => {
     isAdmin,
     callbackId,
     userId,
-    username,
     teamId,
     command,
     ticket: ticket && JSON.parse(ticket),

--- a/server/controllers/handleSlashCommand.js
+++ b/server/controllers/handleSlashCommand.js
@@ -15,11 +15,7 @@ module.exports = async (req, res) => {
    */
 
   const {
-    text,
-    user_id: userId,
-    team_id: teamId,
-    user_name: username,
-    response_url: responseURL,
+    text, user_id: userId, team_id: teamId, response_url: responseURL,
   } = req.body;
 
   // Parse incoming input into command, ticket message and ticket reference number
@@ -28,7 +24,7 @@ module.exports = async (req, res) => {
   // Construct promises array for initial async calls
   const promises = [getUserInfo(userId, teamId)];
   if (number) {
-    promises.push(getTicketByNumber(number));
+    promises.push(getTicketByNumber(number, teamId));
   }
 
   // Get admin status and construct the ticket from new or fetched data
@@ -42,7 +38,6 @@ module.exports = async (req, res) => {
   const responseParams = {
     command,
     userId,
-    username,
     teamId,
     isAdmin,
     ticket,

--- a/server/handlers/slackApiHandlers.js
+++ b/server/handlers/slackApiHandlers.js
@@ -6,6 +6,7 @@ const { getTokensByTeam } = require('./firebaseHandlers');
  * Requires USERS.PROFILE scope in Slack app permissions
  * @param {string} userId
  * @param {string} teamId
+ * @returns {object} user information
  */
 exports.getUserInfo = async (userId, teamId) => {
   const data = {
@@ -16,13 +17,17 @@ exports.getUserInfo = async (userId, teamId) => {
     .post('https://slack.com/api/users.info', { form: data })
     .then((res) => {
       const result = JSON.parse(res);
-      if (result.ok === true) return result.user;
+      if (result.ok) return result.user;
       console.log({ getUserInfoError: result.error });
     })
     .catch(console.log);
 };
 
 /**
+ * Gets team infrmation. Requires TEAM:READ scope in Slac app permissions
+ * @param {string} token
+ * @returns {object} team information
+ */
 exports.getTeamInfo = async token =>
   request
     .post('https://slack.com/api/team.info', { form: { token } })
@@ -33,9 +38,14 @@ exports.getTeamInfo = async token =>
     })
     .catch(console.log);
 
+/**
+ * Notifies a user when their ticket is solved
  * REQUIRES chat:write, im:read, post, read scopes at
  * @param {string} authorId
- * @param {string} message - Message text to send to the user
+ * @param {string} userId
+ * @param {string} teamId
+ * @param {number} ticketNumber
+ * @param {string} text - Message text to send to the user
  */
 exports.sendDM = async (authorId, userId, teamId, ticketNumber, text) => {
   const token = (await getTokensByTeam(teamId)).botToken;
@@ -49,8 +59,15 @@ exports.sendDM = async (authorId, userId, teamId, ticketNumber, text) => {
       token,
       as_user: false,
       id: 'ticket-solved',
-      text: msg.notify(ticketNumber, userId, text),
       channel: JSON.parse(imList).ims.find(ch => ch.user === authorId).id,
+      text: msg.notify.text(userId),
+      attachments: JSON.stringify([
+        {
+          mrkdwn_in: ['text'],
+          text: msg.notify.att(ticketNumber, text),
+          color: '#36a64f',
+        },
+      ]),
     },
   });
 };

--- a/server/handlers/slackApiHandlers.js
+++ b/server/handlers/slackApiHandlers.js
@@ -23,7 +23,16 @@ exports.getUserInfo = async (userId, teamId) => {
 };
 
 /**
- * Notofies user when their ticket is solved
+exports.getTeamInfo = async token =>
+  request
+    .post('https://slack.com/api/team.info', { form: { token } })
+    .then((res) => {
+      const result = JSON.parse(res);
+      if (result.ok) return result.team;
+      console.log({ getTeamError: result.error });
+    })
+    .catch(console.log);
+
  * REQUIRES chat:write, im:read, post, read scopes at
  * @param {string} authorId
  * @param {string} message - Message text to send to the user

--- a/server/utils/attachments.js
+++ b/server/utils/attachments.js
@@ -18,12 +18,7 @@ exports.usage = isAdmin => ({
  * @param{string} userId
  */
 exports.show = ({ isAdmin, userId, teamId }) => {
-  const promises = [fb.getAllSolvedTicketsByUser(userId)];
-  if (isAdmin) {
-    promises.push(fb.getAllOpenTicketsByTeam(teamId));
-  } else {
-    promises.push(fb.getAllOpenTicketsByUser(userId));
-  }
+  const promises = getTicketLists(userId, teamId, isAdmin);
 
   const base = {
     mrkdwn_in: ['pretext', 'text', 'fields'],
@@ -32,9 +27,8 @@ exports.show = ({ isAdmin, userId, teamId }) => {
 
   return Promise.all(promises)
     .then(([solved, open]) => {
-      const ticketsSolved =
-        solved && Object.values(solved).filter(ticket => ticket.team === teamId);
-      const ticketsOpen = open && Object.values(open).filter(ticket => ticket.team === teamId);
+      const ticketsSolved = solved && Object.values(solved);
+      const ticketsOpen = open && Object.values(open);
 
       // If no tickets found in database
       if (!ticketsOpen && !ticketsSolved) {

--- a/server/utils/attachments.js
+++ b/server/utils/attachments.js
@@ -1,9 +1,9 @@
-const fb = require('../handlers/firebaseHandlers');
-const { msg } = require('../utils/helpers');
+const { msg, getTicketLists } = require('../utils/helpers');
 const { examples } = require('../utils/constants');
 
 /**
  * @param {bool} isAdmin - Admin status
+ * @returns {object} formatted response object
  */
 exports.usage = isAdmin => ({
   color: '#36a64f',
@@ -13,9 +13,11 @@ exports.usage = isAdmin => ({
 });
 
 /**
- * @param {bool} isAdmin - Admin status
- * @param {array} tickets - An array of prefetced tickets
- * @param{string} userId
+ * @param {object}
+ * @param {bool} object.isAdmin - Admin status
+ * @param {string} object.userId
+ * @param {string} object.teamId
+ * @returns {object} formatted response object
  */
 exports.show = ({ isAdmin, userId, teamId }) => {
   const promises = getTicketLists(userId, teamId, isAdmin);
@@ -73,12 +75,11 @@ exports.show = ({ isAdmin, userId, teamId }) => {
 };
 
 /**
- * @param {bool} isAdmin -  admin status
- * @param {string} message
- * @returns {object} Response message
+ * Response returned on cancelled action
+ * @returns {object} formatted response object
  */
-exports.helpOrShowInteractive = (isAdmin, message) => ({
-  text: message,
+exports.helpOrShowInteractive = () => ({
+  text: 'Cancelled',
   color: '#F4511E',
   mrkdwn_in: ['text', 'actions'],
   callback_id: 'helpOrShow',
@@ -100,13 +101,15 @@ exports.helpOrShowInteractive = (isAdmin, message) => ({
 });
 
 /**
+ * @param {object}
  * @param {string} command - Initial slash command
  * @param {object} ticket: {id, text, number} - Ticket referenced in a slash command
- * @returns {object} Constructed attachment to send with a response message
+ * @param {bool} adminSelfSolve - if admin is solving his/her own ticket
+ * @returns {object} formatted response object
  */
-exports.confirm = (command, ticket, solveToClose = false) => ({
+exports.confirm = (command, ticket, adminSelfSolve = false) => ({
   color: '#ffd740',
-  text: solveToClose ? msg.confirm.solveToClose(ticket) : msg.confirm.text(command, ticket),
+  text: adminSelfSolve ? msg.confirm.adminSelfSolve(ticket) : msg.confirm.text(command, ticket),
   mrkdwn_in: ['text', 'actions'],
   callback_id: `CONFIRM_${command}`,
   attachment_type: 'default',
@@ -124,7 +127,7 @@ exports.confirm = (command, ticket, solveToClose = false) => ({
       type: 'button',
       value: JSON.stringify(ticket),
     },
-    solveToClose && {
+    adminSelfSolve && {
       name: 'CLOSE',
       text: msg.btn.yes('CLOSE'),
       type: 'button',

--- a/server/utils/attachments.js
+++ b/server/utils/attachments.js
@@ -1,5 +1,7 @@
-const { msg, getTicketLists } = require('../utils/helpers');
+const help = require('../utils/helpers');
 const { examples } = require('../utils/constants');
+
+const { msg } = help;
 
 /**
  * @param {bool} isAdmin - Admin status
@@ -20,7 +22,7 @@ exports.usage = isAdmin => ({
  * @returns {object} formatted response object
  */
 exports.show = ({ isAdmin, userId, teamId }) => {
-  const promises = getTicketLists(userId, teamId, isAdmin);
+  const promises = help.getTicketLists(userId, teamId, isAdmin);
 
   const base = {
     mrkdwn_in: ['pretext', 'text', 'fields'],

--- a/server/utils/helpers.js
+++ b/server/utils/helpers.js
@@ -6,6 +6,16 @@ const { commands, examples, newStatus } = require('../utils/constants');
  */
 const upperCaseFirst = str => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 
+exports.getTicketLists = (userId, teamId, isAdmin) => {
+  const promises = [fb.getAllSolvedTicketsByUser(userId, teamId)];
+  if (isAdmin) {
+    promises.push(fb.getAllOpenTicketsByTeam(teamId));
+  } else {
+    promises.push(fb.getAllOpenTicketsByUser(userId, teamId));
+  }
+  return promises;
+};
+
 /**
  * Parse input received from slack slash command
  * @param {string} inputText

--- a/server/utils/helpers.js
+++ b/server/utils/helpers.js
@@ -1,11 +1,20 @@
-const { commands, examples, newStatus } = require('../utils/constants');
+const { commands, examples } = require('../utils/constants');
+const fb = require('../handlers/firebaseHandlers');
 
 /**
  * Converts to sentence case
  * @param {string} str
+ * @returns {string} String with first letter capitalized
  */
 const upperCaseFirst = str => str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 
+/**
+ * Construct promises array of requested ticket lists
+ * @param {bool} isAdmin
+ * @param {string} userId
+ * @param {string} teamId
+ * @returns {array} promises of ticket lists to be fetched
+ */
 exports.getTicketLists = (userId, teamId, isAdmin) => {
   const promises = [fb.getAllSolvedTicketsByUser(userId, teamId)];
   if (isAdmin) {
@@ -19,6 +28,7 @@ exports.getTicketLists = (userId, teamId, isAdmin) => {
 /**
  * Parse input received from slack slash command
  * @param {string} inputText
+ * @returns {object} Composed parsed command, ticket text and referenced ticket number
  */
 exports.parseInputText = (inputText) => {
   if (!inputText) return { command: 'HELLO' };
@@ -59,6 +69,7 @@ exports.parseInputText = (inputText) => {
   }
 };
 
+// Textual response messages helpers
 exports.msg = {
   hello: { text: ':wave: Hello! Need help with `/ticket`?' },
   help: {
@@ -95,8 +106,8 @@ exports.msg = {
     notAllowed: ':no_entry_sign: Not allowed.',
   },
   confirm: {
-    solveToClose: ({ number, text }) =>
-      `Ticket *#${number}* is yours. Solve or close?\nText: ${text}`,
+    adminSelfSolve: ({ number, text }) =>
+      `This ticket is yours. Solve or close?\n*#${number}* ${text}`,
     text: (command, { number, text, author }) => {
       switch (command) {
         case 'OPEN':
@@ -117,6 +128,8 @@ exports.msg = {
     yes: command => upperCaseFirst(command),
     view: 'View all',
   },
-  notify: (number, userId, text) =>
-    `Your ticket *#${number}* has been solved by <@${userId}>.\nText: ${text}`,
+  notify: {
+    text: user => `Your ticket has been solved by <@${user}>.`,
+    att: (num, text) => `*#${num}* ${text}`,
+  },
 };

--- a/server/utils/responses.js
+++ b/server/utils/responses.js
@@ -2,7 +2,7 @@ const attach = require('./attachments');
 const fb = require('../handlers/firebaseHandlers');
 const { newStatus } = require('../utils/constants');
 const { msg } = require('../utils/helpers');
-const { sendDM } = require('../handlers/slackApiHandlers');
+const slackApi = require('../handlers/slackApiHandlers');
 
 // INITIAL SLASH COMMAND RESPONSES
 
@@ -139,10 +139,11 @@ exports.CONFIRM = async ({
 }) => {
   let message = '';
   if (command === 'OPEN') {
+    text = text.charAt(0).toUpperCase() + text.slice(1); // uppercase first letter
     const num = await fb.addNewTicket({
       userId,
       teamId,
-      text: text.charAt(0).toUpperCase() + text.slice(1), // uppercase first letter
+      text,
     });
     message = msg.confirm.submit(num, text);
   } else {
@@ -150,7 +151,7 @@ exports.CONFIRM = async ({
     await fb.updateTicket(id, author, teamId, status);
     message = msg.confirm.newStatus(number, status);
     if (command === 'SOLVE' && author !== userId) {
-      sendDM(author, userId, teamId, number, text);
+      slackApi.sendDM(author, userId, teamId, number, text);
     }
   }
 

--- a/server/utils/responses.js
+++ b/server/utils/responses.js
@@ -59,7 +59,7 @@ exports.SOLVE = ({
 }) => {
   if (!isAdmin) {
     return { text: msg.error.notAllowed, attachments: [attach.usage(isAdmin)] };
-  } else if (team !== teamId) {
+  } else if (!team) {
     return { text: msg.error.badTeam(number) };
   } else if (status !== 'open') {
     return { text: msg.error.notAllowedStatus(ticket) };
@@ -68,15 +68,11 @@ exports.SOLVE = ({
 };
 
 exports.UNSOLVE = ({
-  command,
-  userId,
-  teamId,
-  ticket,
-  ticket: {
+  command, userId, ticket, ticket: {
     number, author, status, team,
   },
 }) => {
-  if (team !== teamId) {
+  if (!team) {
     return { text: msg.error.badTeam(number) };
   } else if (status !== 'solved') {
     return { text: msg.error.notAllowedStatus(ticket) };
@@ -91,7 +87,7 @@ exports.CLOSE = ({
     number, author, status, team,
   },
 }) => {
-  if (team !== teamId) {
+  if (!team) {
     return { text: msg.error.badTeam(number) };
   } else if (status === 'closed') {
     return { text: msg.error.closed(number) };
@@ -122,9 +118,7 @@ exports.CONFIRM = async ({
     const num = await fb.addNewTicket({
       userId,
       teamId,
-      username,
       text: text.charAt(0).toUpperCase() + text.slice(1), // uppercase first letter
-      isAdmin,
     });
     message = msg.confirm.submit(num, text);
   } else {

--- a/server/utils/responses.js
+++ b/server/utils/responses.js
@@ -4,54 +4,68 @@ const { newStatus } = require('../utils/constants');
 const { msg } = require('../utils/helpers');
 const { sendDM } = require('../handlers/slackApiHandlers');
 
-/**
- * Message responses based on intial slash commands or interactive messages
- * @param {object} responseParams from handleSlashCommand OR handleInteractiveMsg
- * @param {bool} object.isAdmim - Admin status of a user
- * @param {string} obj.command - Initial slash command OR interactive button command
- * @param {object} obj.ticket - An existing ticket referenced in a slash command OR a new ticket from OPEN slash command
- * @param {string} obj.userId
- * @param {string} obj.teamId
- * @param {object} obj.ticket
- */
-
 // INITIAL SLASH COMMAND RESPONSES
 
-// Show open and/or pending tickets and usage instructions
-exports.HELLO = async ({ isAdmin }) => ({
+/**
+ * Show open and/or pending tickets and usage instructions
+ * @param {object} {isAdmin} Admin status
+ * @returns {object} Composed response mesage
+ */
+exports.HELLO = ({ isAdmin }) => ({
   mrkdwn_in: ['text', 'attachments'],
   text: msg.hello.text,
   attachments: [attach.usage(isAdmin)],
 });
 
-// Show usage instructions
+/**
+ * Show usage instructions
+ * @param {object} {isAdmin} Admin status
+ * @returns {object} Composed response mesage
+ */
 exports.HELP = ({ isAdmin }) => ({
   mrkdwn_in: ['text', 'attachments'],
   text: msg.help.text,
   attachments: [attach.usage(isAdmin)],
 });
 
-// Show open tickets to admins and open/solved to users
+/**
+ * Show open tickets to admins and open/solved to users
+ * @param {object} {isAdmin} Admin status
+ * @returns {object} Composed response mesage
+ */
 exports.SHOW = async params => ({
   attachments: [await attach.show(params)],
 });
 
-// Response to unrecognized inputs
+/**
+ * Response to unrecognized inputs
+ * @param {object} {isAdmin} admin status
+ * @returns {object} Composed response mesage
+ */
 exports.ERROR = ({ isAdmin }) => ({
   text: msg.error.text,
   mrkdwn_in: ['text', 'attachments'],
   attachments: [attach.usage(isAdmin)],
 });
 
+/**
+ * @param {object}
+ * @param {string} object.command
+ * @param {object} object.ticket
+ * @returns {object} Composed response mesage
+ */
 exports.OPEN = ({ command, ticket }) => ({
   attachments: [attach.confirm(command, ticket)],
 });
 
+/**
+ * @param {object}
+ * @returns {object} Composed response mesage
+ */
 exports.SOLVE = ({
   isAdmin,
   command,
   userId,
-  teamId,
   ticket,
   ticket: {
     number, team, status, author,
@@ -67,6 +81,10 @@ exports.SOLVE = ({
   return { attachments: [attach.confirm(command, ticket, userId === author)] };
 };
 
+/**
+ * @param {object}
+ * @returns {object} Composed response mesage
+ */
 exports.UNSOLVE = ({
   command, userId, ticket, ticket: {
     number, author, status, team,
@@ -82,8 +100,12 @@ exports.UNSOLVE = ({
   return { attachments: [attach.confirm(command, ticket)] };
 };
 
+/**
+ * @param {object}
+ * @returns {object} Composed response mesage
+ */
 exports.CLOSE = ({
-  command, userId, teamId, ticket, ticket: {
+  command, userId, ticket, ticket: {
     number, author, status, team,
   },
 }) => {
@@ -99,17 +121,19 @@ exports.CLOSE = ({
 
 // INTERACTIVE ACTIONS RESPONSES
 
-exports.CANCEL = ({ isAdmin }) => ({
-  attachments: [attach.helpOrShowInteractive(isAdmin, 'Cancelled.')],
+/**
+ * @returns {object} Composed response mesage
+ */
+exports.CANCEL = () => ({
+  attachments: [attach.helpOrShowInteractive()],
 });
 
+/**
+ * @param {object}
+ * @returns {object} Composed response mesage
+ */
 exports.CONFIRM = async ({
-  isAdmin,
-  command,
-  userId,
-  teamId,
-  username,
-  ticket: {
+  command, userId, teamId, ticket: {
     text, id, author, number,
   },
 }) => {

--- a/tests/firebase.test.js
+++ b/tests/firebase.test.js
@@ -1,0 +1,98 @@
+require('dotenv').load({ path: '.env.test' });
+const fb = require('../server/handlers/firebaseHandlers');
+const { seed } = require('./helper');
+
+const ticket5 = {
+  userId: 'user1',
+  teamId: 'team1',
+  text: 'text5',
+};
+
+describe('Firebase ticket handlers', () => {
+  beforeAll(fb.removeAllTickets);
+
+  let ticketId = null;
+
+  test('Add a new ticket', () =>
+    fb.addNewTicket(ticket5).then((num) => {
+      expect(num).toBe(1);
+    }));
+
+  // Check if simultaneous addNewTicket calls  result in different ticket numbers
+  test('Simultaneously add tickets', () =>
+    Promise.all(seed.map(fb.addNewTicket)).then((res) => {
+      expect(res).toBeInstanceOf(Array);
+      expect(res).toHaveLength(4);
+      expect(res).toEqual([2, 3, 4, 1]); // Returned ticket numbers. The lat one belongs to team2
+    }));
+
+  test('Gets all open tickets by team', () =>
+    fb.getAllOpenTicketsByTeam('team1').then((res) => {
+      expect(res).toBeInstanceOf(Object);
+      // Extract only tickets from normalized response
+      const list = Object.values(res);
+      expect(list).toHaveLength(4);
+      list.forEach((ticket) => {
+        expect(ticket).toHaveProperty('team', 'team1');
+      });
+      // Set ticket id to maipulate
+      ticketId = Object.keys(res)[1];
+    }));
+
+  test('Gets ticket data by its number', () =>
+    fb.getTicketByNumber(2, 'team1').then((ticket) => {
+      expect(ticket).toMatchObject({
+        [ticketId]: {
+          team: 'team1',
+          author: 'user1',
+          number: 2,
+        },
+      });
+    }));
+
+  test('Gets all open tickets by user', () =>
+    fb.getAllOpenTicketsByUser('user1', 'team1').then((list) => {
+      const tickets = Object.values(list);
+      expect(tickets).toHaveLength(3);
+      tickets.forEach((ticket) => {
+        expect(ticket).toMatchObject({
+          author_status: 'user1_open',
+          team: 'team1',
+        });
+      });
+    }));
+
+  test('Updates a ticket', () =>
+    fb.updateTicket(ticketId, 'user1', 'team1', 'solved').then((ticket) => {
+      expect(ticket).toBeInstanceOf(Object);
+      expect(ticket).toMatchObject({
+        status: 'solved',
+        author_status: 'user1_solved',
+      });
+    }));
+
+  test('Gets all solved tickets by user', () => {
+    fb.getAllSolvedTicketsByUser('user1', 'team1').then((ticket) => {
+      expect(ticket).toMatchObject({
+        [ticketId]: {
+          author_status: 'user1_solved',
+          team: 'team1',
+          status: 'solved',
+        },
+      });
+      expect(Object.values(ticket)).toHaveLength(1);
+    });
+  });
+});
+
+describe('Firebase token handlers', () => {
+  const botToken = 'botToken';
+  const accessToken = 'accessToken';
+
+  beforeAll(() => fb.setTokens(ticket5.teamId, accessToken, botToken));
+
+  test('Gets tokens', () =>
+    fb.getTokensByTeam(ticket5.teamId).then((res) => {
+      expect(res).toEqual({ accessToken, botToken });
+    }));
+});

--- a/tests/firebase.test.js
+++ b/tests/firebase.test.js
@@ -8,9 +8,14 @@ const ticket5 = {
   text: 'text5',
 };
 
-describe('Firebase ticket handlers', () => {
-  beforeAll(fb.removeAllTickets);
+beforeAll(() => {
+  fb.removeAllTickets();
+});
+afterAll(() => {
+  fb.removeAllTickets();
+});
 
+describe('Firebase ticket handlers', () => {
   let ticketId = null;
 
   test('Add a new ticket', () =>

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -4,3 +4,26 @@ exports.users = [
   { id: 3, username: 'joe' },
   { id: 4, username: 'julia' },
 ];
+
+exports.seed = [
+  {
+    userId: 'user1',
+    teamId: 'team1',
+    text: 'text1',
+  },
+  {
+    userId: 'user1',
+    teamId: 'team1',
+    text: 'text2',
+  },
+  {
+    userId: 'user2',
+    teamId: 'team1',
+    text: 'text3',
+  },
+  {
+    userId: 'user3',
+    teamId: 'team2',
+    text: 'text4',
+  },
+];

--- a/tests/responses.test.js
+++ b/tests/responses.test.js
@@ -1,0 +1,239 @@
+require('dotenv').load({ path: '.env.test' });
+const fb = require('../server/handlers/firebaseHandlers');
+const res = require('../server/utils/responses');
+const { msg } = require('../server/utils/helpers');
+
+// Params
+let prm = {
+  userId: 'user1',
+  teamId: 'team1',
+  text: 'text1',
+};
+
+describe('General slash command responses', () => {
+  beforeAll(fb.removeAllTickets);
+
+  test('User HELLO command', () => {
+    expect(res.HELLO(prm)).toMatchObject({
+      text: msg.hello.text,
+      attachments: [{ text: msg.help.att(false) }],
+    });
+  });
+
+  test('User HELP command', () => {
+    expect(res.HELP(prm)).toMatchObject({
+      text: msg.help.text,
+      attachments: [{ text: msg.help.att(false) }],
+    });
+  });
+
+  test('User SHOW command with no tickets', () =>
+    res.SHOW(prm).then((res) => {
+      expect(res).toMatchObject({
+        attachments: [{ text: msg.show.list.empty }],
+      });
+    }));
+
+  test('User ERROR command', () => {
+    expect(res.ERROR(prm)).toMatchObject({
+      text: msg.error.text,
+      attachments: [{ text: msg.help.att(false) }],
+    });
+  });
+
+  test('Admin HELLO command', () => {
+    prm.isAdmin = true;
+    expect(res.HELLO(prm)).toMatchObject({
+      text: msg.hello.text,
+      attachments: [{ text: msg.help.att(true) }],
+    });
+  });
+
+  test('Admin HELP command', () => {
+    expect(res.HELP(prm)).toMatchObject({
+      text: msg.help.text,
+      attachments: [{ text: msg.help.att(true) }],
+    });
+  });
+
+  test('CANCEL command', () => {
+    expect(res.CANCEL()).toMatchObject({
+      attachments: [{ text: 'Cancelled' }],
+    });
+    expect(res.CANCEL().attachments[0].actions).toMatchObject([
+      { name: 'HELP' },
+      {
+        name: 'SHOW',
+        text: 'View all',
+      },
+    ]);
+  });
+});
+
+describe('Ticket open-solve-unsolve-close responses flow', () => {
+  test('OPEN command', () => {
+    prm = {
+      ...prm,
+      command: 'OPEN',
+      ticket: { text: 'user1text1' },
+      isAdmin: false,
+    };
+    expect(res.OPEN(prm)).toMatchObject({
+      attachments: [
+        {
+          text: 'Open new ticket with text: user1text1?',
+          actions: expect.any(Array),
+        },
+      ],
+    });
+    expect(res.OPEN(prm).attachments[0].actions).toMatchObject([
+      { name: 'CANCEL' },
+      { name: 'OPEN', value: JSON.stringify({ text: 'user1text1' }) },
+      false,
+    ]);
+  });
+
+  test('User SOLVE command disallowed', () => {
+    prm = { ...prm, command: 'SOLVE' };
+    expect(res.SOLVE(prm)).toMatchObject({
+      text: ':no_entry_sign: Not allowed.',
+      attachments: [{ text: msg.help.att(false) }],
+    });
+  });
+
+  test('Admin SOLVE command with no ticket found', () => {
+    prm = { ...prm, isAdmin: true, ticket: { number: 99 } };
+    expect(res.SOLVE(prm)).toMatchObject({ text: msg.error.badTeam(prm.ticket.number) });
+  });
+
+  test("Admin SOLVE command with status !== 'open'", () => {
+    prm.ticket = {
+      text: 'user1text1',
+      number: 10,
+      team: 'team1',
+      author: 'badAuthor',
+      status: 'solved',
+    };
+    expect(res.SOLVE(prm)).toMatchObject({ text: msg.error.notAllowedStatus(prm.ticket) });
+  });
+
+  test('Admin SOLVE command with author !== user', () => {
+    prm.ticket.status = 'open';
+    expect(res.SOLVE(prm)).toMatchObject({
+      attachments: [
+        {
+          text: msg.confirm.text(prm.command, prm.ticket),
+          actions: expect.any(Array),
+        },
+      ],
+    });
+    expect(res.SOLVE(prm).attachments[0].actions).toMatchObject([
+      { name: 'CANCEL' },
+      { name: 'SOLVE', value: JSON.stringify(prm.ticket) },
+      false,
+    ]);
+  });
+
+  test('Admin SOLVE command with author === user', () => {
+    prm.ticket.author = prm.userId;
+    expect(res.SOLVE(prm)).toMatchObject({
+      attachments: [
+        {
+          text: msg.confirm.adminSelfSolve(prm.ticket),
+          actions: expect.any(Array),
+        },
+      ],
+    });
+    expect(res.SOLVE(prm).attachments[0].actions).toMatchObject([
+      { name: 'CANCEL' },
+      { name: 'SOLVE', value: JSON.stringify(prm.ticket) },
+      { name: 'CLOSE' },
+    ]);
+  });
+
+  test('UNSOLVE command with no ticket found', () => {
+    prm = { ...prm, command: 'UNSOLVE', ticket: { number: 99 } };
+    expect(res.UNSOLVE(prm)).toMatchObject({ text: msg.error.badTeam(prm.ticket.number) });
+  });
+
+  test('UNSOLVE command with status !== "solved"', () => {
+    prm.ticket = {
+      text: 'user1text1',
+      number: 10,
+      team: 'team1',
+      author: 'badAuthor',
+      status: 'open',
+    };
+    expect(res.UNSOLVE(prm)).toMatchObject({
+      text: ':no_entry_sign: Not allowed. Ticket *#10* from <@badAuthor> is *open*.',
+    });
+  });
+
+  test("UNSOLVE command with author !== 'user'", () => {
+    prm.ticket.status = 'solved';
+    expect(res.UNSOLVE(prm)).toMatchObject({
+      text: ':no_entry_sign: Ticket *#10* is not yours.',
+    });
+  });
+
+  test('UNSOLVE command with correct params', () => {
+    prm.ticket.author = 'user1';
+    expect(res.UNSOLVE(prm)).toMatchObject({
+      attachments: [
+        {
+          text: 'Unsolve ticket *#10*: user1text1?',
+          actions: expect.any(Array),
+        },
+      ],
+    });
+    expect(res.UNSOLVE(prm).attachments[0].actions).toMatchObject([
+      { name: 'CANCEL' },
+      { name: 'UNSOLVE', value: JSON.stringify(prm.ticket) },
+      false,
+    ]);
+  });
+
+  test('CLOSE command with no ticket found', () => {
+    prm = { ...prm, command: 'CLOSE', ticket: { number: 99 } };
+    expect(res.CLOSE(prm)).toMatchObject({
+      text: msg.error.badTeam(prm.ticket.number),
+    });
+  });
+
+  test('CLOSE command with status === "closed"', () => {
+    prm.ticket = {
+      text: 'user1text1',
+      number: 10,
+      team: 'team1',
+      author: 'badAuthor',
+      status: 'closed',
+    };
+    expect(res.CLOSE(prm)).toMatchObject({
+      text: msg.error.closed(prm.ticket.number),
+    });
+  });
+
+  test('CLOSE command with author !== user', () => {
+    prm.ticket.status = 'solved';
+    expect(res.CLOSE(prm)).toMatchObject({
+      text: msg.error.notAuthor(prm.ticket.number),
+    });
+  });
+
+  test('CLOSE command with correct params', () => {
+    prm.ticket.author = prm.userId;
+    expect(res.CLOSE(prm)).toMatchObject({
+      attachments: [
+        {
+          text: 'Close ticket *#10*: user1text1?',
+          actions: expect.any(Array),
+        },
+      ],
+    });
+    expect(res.CLOSE(prm).attachments[0].actions).toMatchObject([
+      { name: 'CANCEL' },
+      { name: 'CLOSE', value: JSON.stringify(prm.ticket) },
+      false,
+    ]);
+  });
+});


### PR DESCRIPTION
### Summary
- Added  firebase, slash-command and slash-command responses tests
- Updated firebase handlers
  - Grouped database ticket records by teams (to avoid too many concurrent counter updates)
  - Ticket counters are now separated by teams and `ticketIncrement` handler directly returns new counter value
- Added `getTeamInfo` slack API handler to fetch the team domain name
- Updated comments